### PR TITLE
Lock Packages to Specific Versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,10 @@ setuptools.setup(
         'tap_pagerduty': ['schemas/*.json']
     },
     install_requires=[
-        'requests>=2.22.0',
-        'singer-python>=5.8.1',
-        'backoff>=1.8.0',
-        'rollbar>=0.14.7'
+        'requests==2.22.0',
+        'singer-python==5.9.0',
+        'backoff==1.8.0',
+        'rollbar==0.14.7'
     ],
     python_requires='>=3.6',
     entry_points={


### PR DESCRIPTION
This PR updates the dependencies for `tap-pagerduty` to be locked to explicit versions. The previous dependency restrictions were causing versions conflicts when using the `--pre` flag with `pip`.